### PR TITLE
SVCPLAN-6652: Add syslog class to track specific GitLab logs via syslog

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,10 @@ The goal is that no paramters are required to be set. The default paramters shou
 - [ncsa/profile_backup](https://github.com/ncsa/puppet-profile_backup)
 - [ncsa/sshd](https://github.com/ncsa/puppet-sshd)
 - [puppet/gitlab](https://forge.puppet.com/modules/puppet/gitlab)
+- [puppet/rsyslog](https://forge.puppet.com/modules/puppet/rsyslog)
 - [puppetlabs/firewall](https://forge.puppet.com/modules/puppetlabs/firewall)
 
 
 ## Reference
-
-### class profile_gitlab::firewall (
--  Hash[String,String] $http_allowed_subnets,
--  Hash[String,String] $https_allowed_subnets,
-### class profile_gitlab::ssh (
--  Array[ String ] $allowed_subnets,
 
 See: [REFERENCE.md](REFERENCE.md)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -10,6 +10,7 @@
 * [`profile_gitlab::backup`](#profile_gitlab--backup): Configure GitLab backups
 * [`profile_gitlab::firewall`](#profile_gitlab--firewall): Open GitLab ports in the firewall
 * [`profile_gitlab::ssh`](#profile_gitlab--ssh): Configure ssh access to GitLab for git clients
+* [`profile_gitlab::syslog`](#profile_gitlab--syslog): Configure syslog related to GitLab
 
 ## Classes
 
@@ -117,4 +118,28 @@ The following parameters are available in the `profile_gitlab::ssh` class:
 Data type: `Array[String]`
 
 List of subnets allowed SSH access
+
+### <a name="profile_gitlab--syslog"></a>`profile_gitlab::syslog`
+
+Configure syslog related to GitLab
+
+#### Examples
+
+##### 
+
+```puppet
+include profile_gitlab::syslog
+```
+
+#### Parameters
+
+The following parameters are available in the `profile_gitlab::syslog` class:
+
+* [`path`](#-profile_gitlab--syslog--path)
+
+##### <a name="-profile_gitlab--syslog--path"></a>`path`
+
+Data type: `String`
+
+Path to GitLab logs
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -20,3 +20,4 @@ profile_gitlab::firewall::https_allowed_subnets:
   #"SSLlabs testing": "64.41.200.96/28"
 profile_gitlab::ssh::allowed_subnets:
   - "0.0.0.0/0"  # Public
+profile_gitlab::syslog::path: "/var/log/gitlab"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,4 +7,5 @@ class profile_gitlab {
   include profile_gitlab::backup
   include profile_gitlab::firewall
   include profile_gitlab::ssh
+  include profile_gitlab::syslog
 }

--- a/manifests/syslog.pp
+++ b/manifests/syslog.pp
@@ -1,0 +1,50 @@
+# @summary Configure syslog related to GitLab
+#
+# @param path
+#   Path to GitLab logs
+#
+# @example
+#   include profile_gitlab::syslog
+class profile_gitlab::syslog (
+  String $path,
+) {
+  include rsyslog
+
+  # Define the rsyslog module
+  rsyslog::component::module { 'imfile':
+    confdir  => $rsyslog::confdir,
+    priority => $rsyslog::module_load_priority,
+    target   => '75_gitlab.conf',
+  }
+
+  Rsyslog::Component::Input {
+    confdir  => $rsyslog::confdir,
+    priority => $rsyslog::input_priority,
+    target   => '75_gitlab.conf',
+    type     => 'imfile',
+  }
+
+  $rsyslog_input_default_params = {
+    facility => 'local0',
+    severity => 'info',
+  }
+
+  # Define the rsyslog inputs dynamically
+  $gitlab_logs = [
+    { file => "${profile_gitlab::syslog::path}/nginx/gitlab_access.log", tag => 'gitlab-access' },
+    { file => "${profile_gitlab::syslog::path}/gitaly/current", tag => 'gitlab-gitaly' },
+    { file => "${profile_gitlab::syslog::path}/gitlab-pages/current", tag => 'gitlab-pages' },
+    { file => "${profile_gitlab::syslog::path}/registry/current", tag => 'gitlab-registry' },
+    { file => "${profile_gitlab::syslog::path}/gitlab-shell/gitlab-shell.log", tag => 'gitlab-shell' },
+    { file => "${profile_gitlab::syslog::path}/sidekiq/current", tag => 'gitlab-sidekiq' },
+    { file => "${profile_gitlab::syslog::path}/gitlab-workhorse/current", tag => 'gitlab-workhorse' },
+  ]
+  $gitlab_logs.each |$log| {
+    rsyslog::component::input { $log['tag']:
+      config => merge($rsyslog_input_default_params, {
+          file => $log['file'],
+          tag  => $log['tag'],
+      }),
+    }
+  }
+}

--- a/spec/classes/syslog_spec.rb
+++ b/spec/classes/syslog_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_gitlab::syslog' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile.with_all_deps }
+    end
+  end
+end


### PR DESCRIPTION
Fix #7.

This has been tested on `git-test`. And the resulting changes are already manually applied to the production `git` server.